### PR TITLE
Upgrade require_all to 2.0

### DIFF
--- a/lib/odyssey.rb
+++ b/lib/odyssey.rb
@@ -60,4 +60,5 @@ end
 
 require 'require_all'
 require 'odyssey/engine'
+require_rel 'formulas/formula'
 require_rel 'formulas'

--- a/odyssey.gemspec
+++ b/odyssey.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-  spec.add_dependency "require_all"
+  spec.add_dependency "require_all", "~> 2.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
This is in response to a breaking change introduced by require_all 2.0

When using require_all 2.0, the gem runs into an error when requiring
`lib/formulas`, as each file is loaded in alphabetical order, which
means that some formulas that are subclasses of Formula are loaded
before `lib/formulas/formula.rb`, resulting in a RequireAll::LoadError
for the uninitialized constant Formula.

This is easily fixed by requiring `lib/formulas/formula.rb` before
`lib/formulas`. Also, explicit versioning of require_all is introduced
to prevent future errors of this kind.