### PR TITLE
remove required version of bundler from gemspec

### DIFF
--- a/odyssey.gemspec
+++ b/odyssey.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.1.0"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Most people are using Bundler 2, so the version here is too restrictive.

Since it's a development dependency, this isn't impacting users, so this
is pretty low priority.