### PR TITLE
Add Rubygems badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Odyssey
 
+[![Gem Version](https://badge.fury.io/rb/odyssey.svg)](https://badge.fury.io/rb/odyssey)
+
 Odyssey is an extendible text analyzing gem that outputs the readability score of text. It has several of the common readability formulas available, but defaults to the Flesch-Kincaid Reading Ease score.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example:
 
     Odyssey.flesch_kincaid_re("See Spot run.", true)
 
-if all_stats is false, this returns a simple score. If it is true, it returns a Hash:
+if `all_stats` is false, this returns a simple score. If it is true, it returns a Hash:
 
 
     {


### PR DESCRIPTION
Adds the rubygems badge to the README, and fixes a small README typo.

@lahnerml @cameronsutter I'd like to push a tag for `v0.3.0` as well, so people can easily find which version is on Rubygems - let me know if I should do that, or if one of you wants to take care of it.

Thanks