### PR TITLE
remove explicit rspec version

### DIFF
--- a/odyssey.gemspec
+++ b/odyssey.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.1.0"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'odyssey'
 RSpec.configure do |config|
   config.color = true
   config.formatter     = 'documentation'
+  config.expect_with(:rspec) { |c| c.syntax = %i[should expect] }
 end
 
 def one_simple_sentence


### PR DESCRIPTION
Also updates the rspec configuration to silence deprecation warnings for
`should_not`.