### PR TITLE
add an odyssey executable (cli)

### DIFF
--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,12 @@
+*.gem
+.bundle
+.config
+.yardoc
+Gemfile.lock
+coverage
+doc/
+pkg
+spec/reports
+test/tmp
+test/version_tmp
+tmp

--- a/cli/Gemfile
+++ b/cli/Gemfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+gemspec

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,38 @@
+# odyssey-cli
+
+[![Gem Version](https://badge.fury.io/rb/odyssey-cli.svg)](https://badge.fury.io/rb/odyssey-cli)
+
+CLI for the ruby text analysis gem odyssey.
+
+## Installation
+
+Install the executable like so
+
+```
+gem install odyssey-cli
+```
+
+## Usage
+
+```
+odyssey score moby_dick.txt      # Outputs all readability scores
+odyssey score othello.txt -f ari # Outputs ARI score only (or use `--formula=`)
+```
+
+For detailed usage, see
+
+- `odyssey help` and `odyssey help score`
+
+Additionally, you can check out the [cli spec](spec/odyssey/cli/cli_spec.rb) for some examples.
+
+## License
+
+Released under the same license as odyssey itself, see [it's license](../LICENSE.txt).
+
+## Contributing
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request

--- a/cli/Rakefile
+++ b/cli/Rakefile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+end
+
+task default: :spec

--- a/cli/exe/odyssey
+++ b/cli/exe/odyssey
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'odyssey/cli'
+
+Odyssey::CLI::CLI.start ARGV

--- a/cli/lib/odyssey/cli.rb
+++ b/cli/lib/odyssey/cli.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'odyssey'
+require 'terminal-table'
+require 'thor'
+
+module Odyssey
+  module CLI
+    class CLI < Thor
+      PROGRAM_NAME = 'odyssey'
+
+      SCORES = {
+        'ari'          => {
+          method: :ari,
+          name: 'Automated Readability Index',
+          key: '1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level',
+          class: 'Ari'
+        },
+        'coleman-liau' => {
+          method: :coleman_liau,
+          name: 'Coleman Liau Index',
+          key: '1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level',
+          class: 'ColemanLiau'
+        },
+        'grade-level'  => {
+          method: :flesch_kincaid_gl,
+          name: 'Flesch Kincaid Grade Level',
+          key: '1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level',
+          class: 'FleshKincaidGl'
+        },
+        'reading-ease' => {
+          method: :flesch_kincaid_re,
+          name: 'Flesch Kincaid Reading Ease',
+          key: '7          => 7th grade     | 10        => 10th Grade | 13-16     => College Level',
+          class: 'FleshKincaidRe'
+        },
+        'gunning-fog'  => {
+          method: :gunning_fog,
+          name: 'Gunning Fog Index',
+          key: '7          => 7th grade     | 10        => 10th Grade | 13-16     => College Level',
+          class: 'GunningFog'
+        },
+        'smog'         => {
+          method: :smog,
+          name: 'Smog Index',
+          key: '100.0-90.0 => 5th Grade     | 80.0-70.0 => 7th Grade  | 50.0-30.0 => College Level',
+          class: 'Smog'
+        }
+      }.freeze
+
+      desc 'score <TEXT_FILE>', 'output scores/metrics for a file'
+      option :formulas,
+             aliases: '-f',
+             type: :array,
+             desc: 'Formulas to compute (space-separated)',
+             default: SCORES.keys,
+             enum: SCORES.keys
+      def score text_file
+        puts "\nChecking the contents of #{text_file} ...\n\n"
+
+        content = File.read text_file
+
+        results = Odyssey.analyze_multi \
+          content,
+          options[:formulas].map { |f| SCORES[f][:class] },
+          true
+
+        headers = %w[Name Score Interpretation]
+
+        rows = options[:formulas].map do |f|
+          [
+            SCORES[f][:name],
+            results['scores'][SCORES[f][:class]],
+            SCORES[f][:key]
+          ]
+        end
+
+        table = Terminal::Table.new headings: headers, rows: rows
+
+        puts table, "\n"
+      rescue StandardError => e
+        puts "\n`#{PROGRAM_NAME}` has encountered an error.\n"
+        puts "#{e.message}: \n#{e.backtrace}"
+      end
+    end
+  end
+end

--- a/cli/lib/odyssey/cli/version.rb
+++ b/cli/lib/odyssey/cli/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Odyssey
+  module CLI
+    VERSION = '0.1.0'
+  end
+end

--- a/cli/odyssey-cli.gemspec
+++ b/cli/odyssey-cli.gemspec
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative 'lib/odyssey/cli/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'odyssey-cli'
+  spec.version       = Odyssey::CLI::VERSION
+  spec.authors       = ['Mark Delk']
+
+  spec.summary       = 'CLI for the odyssey gem'
+  spec.homepage      = 'https://github.com/cameronsutter/odyssey/cli'
+  spec.license       = 'MIT'
+
+  spec.required_ruby_version = Gem::Requirement.new '>= 2.3.0'
+
+  spec.metadata = {
+    'allowed_push_host' => 'https://rubygems.org/',
+    'homepage_uri'      => spec.homepage,
+    'source_code_uri'   => spec.homepage
+  }
+
+  spec.files = Dir.chdir (Pathname.new(__dir__) + '..').realpath do
+    `git ls-files -z --directory ./cli/`
+      .split("\x0")
+      .select { |f| f.match %r{^cli/} }
+      .reject { |f| f.match %r{^(test|spec|features)/} }
+      .map    { |f| f.sub 'cli/', '' }
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename f }
+  spec.require_paths = ['lib']
+
+  {
+    'odyssey'        => '~> 0.3.0',
+    'terminal-table' => '~> 1.8',
+    'thor'           => '~> 0.20.3'
+  }.each do |gem, version|
+    spec.add_dependency gem, version
+  end
+
+  {
+    'aruba'      => '~> 0.14.11',
+    'bundler'    => '~> 2.0',
+    'pry'        => '~> 0.12.2',
+    'pry-byebug' => '~> 3.7',
+    'rake'       => '~> 12.3',
+    'rspec'      => '~> 3.8',
+    'rubocop'    => '~> 0.72.0'
+  }.each do |gem, version|
+    spec.add_development_dependency gem, version
+  end
+end

--- a/cli/spec/odyssey/cli/cli_spec.rb
+++ b/cli/spec/odyssey/cli/cli_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'odyssey cli', type: :aruba do
+  def odyssey command_string = nil
+    run_command "bundle exec ../../exe/odyssey #{command_string}"
+  end
+
+  describe '`score`' do
+    context 'without arguments' do
+      it 'errors and shows usage' do
+        odyssey
+
+        expect(last_command_stopped.output).to eq <<~CMD
+          Commands:
+            odyssey help [COMMAND]     # Describe available commands or one specific command
+            odyssey score <TEXT_FILE>  # output scores/metrics for a file
+
+        CMD
+      end
+    end
+
+    context 'given a filename' do
+      it 'shows all scores and metrics for the supplied file' do
+        odyssey 'score ../../../LICENSE.txt'
+
+        expect(last_command_stopped.output).to eq <<~CMD
+
+          Checking the contents of ../../../LICENSE.txt ...
+
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Name                        | Score | Interpretation                                                                     |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Automated Readability Index | 30.8  | 1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level |
+          | Coleman Liau Index          | 13.4  | 1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level |
+          | Flesch Kincaid Grade Level  | 0     | 1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level |
+          | Flesch Kincaid Reading Ease | 0     | 7          => 7th grade     | 10        => 10th Grade | 13-16     => College Level |
+          | Gunning Fog Index           | 23.1  | 7          => 7th grade     | 10        => 10th Grade | 13-16     => College Level |
+          | Smog Index                  | 25.0  | 100.0-90.0 => 5th Grade     | 80.0-70.0 => 7th Grade  | 50.0-30.0 => College Level |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+
+        CMD
+      end
+    end
+
+    context 'given a filename and a set of formulas' do
+      it 'shows only those scores and metrics for the supplied file' do
+        odyssey 'score ../../../LICENSE.txt --formulas ari smog'
+
+        expect(last_command_stopped.output).to eq <<~CMD
+
+          Checking the contents of ../../../LICENSE.txt ...
+
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Name                        | Score | Interpretation                                                                     |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Automated Readability Index | 30.8  | 1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level |
+          | Smog Index                  | 25.0  | 100.0-90.0 => 5th Grade     | 80.0-70.0 => 7th Grade  | 50.0-30.0 => College Level |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+
+        CMD
+      end
+
+      it 'also has a short `-f` option' do
+        odyssey 'score ../../../LICENSE.txt -f grade-level reading-ease'
+
+        expect(last_command_stopped.output).to eq <<~CMD
+
+          Checking the contents of ../../../LICENSE.txt ...
+
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Name                        | Score | Interpretation                                                                     |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+          | Flesch Kincaid Grade Level  | 0     | 1          => Kindergarten  | 8         => 7th Grade  | 14+       => College Level |
+          | Flesch Kincaid Reading Ease | 0     | 7          => 7th grade     | 10        => 10th Grade | 13-16     => College Level |
+          +-----------------------------+-------+------------------------------------------------------------------------------------+
+
+        CMD
+      end
+    end
+  end
+
+  describe 'help' do
+    context 'without arguments' do
+      it 'shows the basic help command' do
+        odyssey 'help'
+
+        expect(last_command_stopped.output).to eq <<~CMD
+          Commands:
+            odyssey help [COMMAND]     # Describe available commands or one specific command
+            odyssey score <TEXT_FILE>  # output scores/metrics for a file
+
+        CMD
+      end
+    end
+
+    context '`score`' do
+      it 'shows help for the `score` command' do
+        odyssey 'help score'
+
+        expect(last_command_stopped.output).to eq <<~CMD
+          Usage:
+            odyssey score <TEXT_FILE>
+
+          Options:
+            -f, [--formulas=one two three]  # Formulas to compute (space-separated)
+                                            # Default: ["ari", "coleman-liau", "grade-level", "reading-ease", "gunning-fog", "smog"]
+                                            # Possible values: ari, coleman-liau, grade-level, reading-ease, gunning-fog, smog
+
+          output scores/metrics for a file
+        CMD
+      end
+    end
+  end
+end

--- a/cli/spec/spec_helper.rb
+++ b/cli/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+require 'odyssey'
+require 'rspec'
+require 'aruba/rspec'
+require 'pathname'
+
+module Helpers
+  def cli_gem_root
+    (Pathname.new(__dir__) + '..').realpath
+  end
+end
+
+RSpec.configure do |c|
+  c.color = true
+  c.formatter = 'documentation'
+  c.expect_with(:rspec) { |c| c.syntax = %i[expect] }
+  c.include Helpers
+end


### PR DESCRIPTION
Adds another gem, `odyssey-cli`, that's just a command line wrapper around odyssey.

## Discussion point:

Should this be implemented using `OptionParser`, and no external dependencies (currently uses `thor`)? 

##### Pros

If will have no dependencies, so we _could_ include it in the main gem.

##### Cons

Much more work to **not** use `thor`, or some equivalent command line interface generator

## TODO

- [ ] support JSON output
- [ ] show other metrics (number syllables, etc)
- [ ] print the `interpretation` section without hard-coding
- [ ] enable output of each score in a simple format, for use in scripts, for example