### PR TITLE
Add changelog for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2019-10-01
+
+**No breaking changes from 0.3.0**
+
+### Added
+
+- Updated specs to use larger examples by [@jethrodaniel](https://github.com/jethrodaniel)
+
+## [0.3.0] - 2019-07-05
+
+Added before implementing this change log.
+
+## [0.2.0]
+
+Added before implementing this change log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **No breaking changes from 0.3.0**
 
-### Added
+### Changed
 
 - Updated specs to use larger examples by [@jethrodaniel](https://github.com/jethrodaniel)
 
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Added before implementing this change log.
 
-## [0.2.0]
+## [0.2.0] - 2016-04-05
+
+Added before implementing this change log.
+
+## [0.1.8] - 2013-06-13
 
 Added before implementing this change log.


### PR DESCRIPTION
Resolves https://github.com/cameronsutter/odyssey/issues/30

The exact date for `v1.0.0` will need to be updated here as well.

@lahnerml @cameronsutter I'll update the change log and push the gem to rubygems when this PR is approved.