### PR TITLE
Better spec data

### DIFF
--- a/odyssey.gemspec
+++ b/odyssey.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "activesupport", "~> 5.2"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/spec/fixtures/README.md
+++ b/spec/fixtures/README.md
@@ -1,0 +1,7 @@
+# odyssey/spec/fixtures
+
+This directory provides testing data.
+
+## Copyright
+
+All works are in the public domain.

--- a/spec/fixtures/fire_and_ice.yml
+++ b/spec/fixtures/fire_and_ice.yml
@@ -1,0 +1,37 @@
+---
+
+text: |
+  Some say the world will end in fire,
+  Some say in ice.
+  From what I’ve tasted of desire
+  I hold with those who favor fire.
+  But if it had to perish twice,
+  I think I know enough of hate
+  To say that for destruction ice
+  Is also great
+  And would suffice.
+
+title: Fire and Ice
+author: Robert Frost
+publication_date:
+  year: 1923
+source: https://web.archive.org/web/20190211010001/https://www.gutenberg.org/files/58611/58611-0.txt
+
+data:
+  letter_count: 189
+  word_count: 52
+  three_plus_syllables: 2
+  syllable_count: 60
+  sentence_count:  3
+  string_length: 245
+  average_syllables_per_word: 1.1538461538461537
+  average_words_per_sentence: 17.333333333333332
+  note: |
+
+scores:
+  flesch_kincaid_reading_ease: 91.6
+  flesch_kincaid_grade_level: 4.8
+  gunning_fog: 6.9
+  coleman_liau: 5.6
+  smog: 9.7
+  ari: 4.4

--- a/spec/fixtures/on_the_duty_of_civil_disobedience.yml
+++ b/spec/fixtures/on_the_duty_of_civil_disobedience.yml
@@ -1,0 +1,853 @@
+---
+
+title: On the Duty of Civil Disobedience
+author: Henry David Thoreau
+publication_date:
+  year: 1849
+source: http://web.archive.org/web/20180826212146/https://www.gutenberg.org/files/205/205-0.txt
+
+data:
+  letter_count: 40273
+  word_count: 9392
+  three_plus_syllables:
+  syllable_count: 13236
+  sentence_count: 325
+  string_length: 51190
+  average_syllables_per_word: 1.4092844974446337
+  average_words_per_sentence: 28.89846153846154
+  note: |
+    This text is formatted as markdown, and has literal double quotes and
+    em dashes.
+
+scores:
+  flesch_kincaid_reading_ease: 58.3
+  flesch_kincaid_grade_level: 12.3
+  gunning_fog: 11.6
+  coleman_liau: 9.4
+  smog: 17.1
+  ari: 13.2
+
+text: |
+  I heartily accept the motto,—“That government is best which governs
+  least;” and I should like to see it acted up to more rapidly and
+  systematically. Carried out, it finally amounts to this, which also I
+  believe—“That government is best which governs not at all;” and when
+  men are prepared for it, that will be the kind of government which they
+  will have. Government is at best but an expedient; but most governments
+  are usually, and all governments are sometimes, inexpedient. The
+  objections which have been brought against a standing army, and they
+  are many and weighty, and deserve to prevail, may also at last be
+  brought against a standing government. The standing army is only an arm
+  of the standing government. The government itself, which is only the
+  mode which the people have chosen to execute their will, is equally
+  liable to be abused and perverted before the people can act through it.
+  Witness the present Mexican war, the work of comparatively a few
+  individuals using the standing government as their tool; for, in the
+  outset, the people would not have consented to this measure.
+
+  This American government,—what is it but a tradition, though a recent
+  one, endeavoring to transmit itself unimpaired to posterity, but each
+  instant losing some of its integrity? It has not the vitality and force
+  of a single living man; for a single man can bend it to his will. It is
+  a sort of wooden gun to the people themselves; and, if ever they should
+  use it in earnest as a real one against each other, it will surely
+  split. But it is not the less necessary for this; for the people must
+  have some complicated machinery or other, and hear its din, to satisfy
+  that idea of government which they have. Governments show thus how
+  successfully men can be imposed on, even impose on themselves, for
+  their own advantage. It is excellent, we must all allow; yet this
+  government never of itself furthered any enterprise, but by the
+  alacrity with which it got out of its way. _It_ does not keep the
+  country free. _It_ does not settle the West. _It_ does not educate. The
+  character inherent in the American people has done all that has been
+  accomplished; and it would have done somewhat more, if the government
+  had not sometimes got in its way. For government is an expedient, by
+  which men would fain succeed in letting one another alone; and, as has
+  been said, when it is most expedient, the governed are most let alone
+  by it. Trade and commerce, if they were not made of India rubber, would
+  never manage to bounce over obstacles which legislators are continually
+  putting in their way; and, if one were to judge these men wholly by the
+  effects of their actions, and not partly by their intentions, they
+  would deserve to be classed and punished with those mischievous persons
+  who put obstructions on the railroads.
+
+  But, to speak practically and as a citizen, unlike those who call
+  themselves no-government men, I ask for, not at once no government, but
+  _at once_ a better government. Let every man make known what kind of
+  government would command his respect, and that will be one step toward
+  obtaining it.
+
+  After all, the practical reason why, when the power is once in the
+  hands of the people, a majority are permitted, and for a long period
+  continue, to rule, is not because they are most likely to be in the
+  right, nor because this seems fairest to the minority, but because they
+  are physically the strongest. But a government in which the majority
+  rule in all cases can not be based on justice, even as far as men
+  understand it. Can there not be a government in which the majorities do
+  not virtually decide right and wrong, but conscience?—in which
+  majorities decide only those questions to which the rule of expediency
+  is applicable? Must the citizen ever for a moment, or in the least
+  degree, resign his conscience to the legislator? Why has every man a
+  conscience, then? I think that we should be men first, and subjects
+  afterward. It is not desirable to cultivate a respect for the law, so
+  much as for the right. The only obligation which I have a right to
+  assume, is to do at any time what I think right. It is truly enough
+  said that a corporation has no conscience; but a corporation of
+  conscientious men is a corporation _with_ a conscience. Law never made
+  men a whit more just; and, by means of their respect for it, even the
+  well-disposed are daily made the agents of injustice. A common and
+  natural result of an undue respect for the law is, that you may see a
+  file of soldiers, colonel, captain, corporal, privates, powder-monkeys
+  and all, marching in admirable order over hill and dale to the wars,
+  against their wills, aye, against their common sense and consciences,
+  which makes it very steep marching indeed, and produces a palpitation
+  of the heart. They have no doubt that it is a damnable business in
+  which they are concerned; they are all peaceably inclined. Now, what
+  are they? Men at all? or small movable forts and magazines, at the
+  service of some unscrupulous man in power? Visit the Navy Yard, and
+  behold a marine, such a man as an American government can make, or such
+  as it can make a man with its black arts, a mere shadow and
+  reminiscence of humanity, a man laid out alive and standing, and
+  already, as one may say, buried under arms with funeral accompaniment,
+  though it may be
+
+       “Not a drum was heard, not a funeral note,
+           As his corpse to the ramparts we hurried;
+       Not a soldier discharged his farewell shot
+           O’er the grave where our hero we buried.”
+
+  The mass of men serve the State thus, not as men mainly, but as
+  machines, with their bodies. They are the standing army, and the
+  militia, jailers, constables, _posse comitatus_, &c. In most cases
+  there is no free exercise whatever of the judgment or of the moral
+  sense; but they put themselves on a level with wood and earth and
+  stones; and wooden men can perhaps be manufactured that will serve the
+  purpose as well. Such command no more respect than men of straw, or a
+  lump of dirt. They have the same sort of worth only as horses and dogs.
+  Yet such as these even are commonly esteemed good citizens. Others, as
+  most legislators, politicians, lawyers, ministers, and office-holders,
+  serve the state chiefly with their heads; and, as they rarely make any
+  moral distinctions, they are as likely to serve the devil, without
+  _intending_ it, as God. A very few, as heroes, patriots, martyrs,
+  reformers in the great sense, and _men_, serve the State with their
+  consciences also, and so necessarily resist it for the most part; and
+  they are commonly treated by it as enemies. A wise man will only be
+  useful as a man, and will not submit to be “clay,” and “stop a hole to
+  keep the wind away,” but leave that office to his dust at least:
+
+       “I am too high-born to be propertied,
+       To be a secondary at control,
+       Or useful serving-man and instrument
+       To any sovereign state throughout the world.”
+
+  He who gives himself entirely to his fellow-men appears to them useless
+  and selfish; but he who gives himself partially to them is pronounced a
+  benefactor and philanthropist.
+
+  How does it become a man to behave toward the American government
+  today? I answer that he cannot without disgrace be associated with it.
+  I cannot for an instant recognize that political organization as _my_
+  government which is the _slave’s_ government also.
+
+  All men recognize the right of revolution; that is, the right to refuse
+  allegiance to and to resist the government, when its tyranny or its
+  inefficiency are great and unendurable. But almost all say that such is
+  not the case now. But such was the case, they think, in the Revolution
+  of ’75. If one were to tell me that this was a bad government because
+  it taxed certain foreign commodities brought to its ports, it is most
+  probable that I should not make an ado about it, for I can do without
+  them: all machines have their friction; and possibly this does enough
+  good to counter-balance the evil. At any rate, it is a great evil to
+  make a stir about it. But when the friction comes to have its machine,
+  and oppression and robbery are organized, I say, let us not have such a
+  machine any longer. In other words, when a sixth of the population of a
+  nation which has undertaken to be the refuge of liberty are slaves, and
+  a whole country is unjustly overrun and conquered by a foreign army,
+  and subjected to military law, I think that it is not too soon for
+  honest men to rebel and revolutionize. What makes this duty the more
+  urgent is that fact, that the country so overrun is not our own, but
+  ours is the invading army.
+
+  Paley, a common authority with many on moral questions, in his chapter
+  on the “Duty of Submission to Civil Government,” resolves all civil
+  obligation into expediency; and he proceeds to say, “that so long as
+  the interest of the whole society requires it, that is, so long as the
+  established government cannot be resisted or changed without public
+  inconveniency, it is the will of God that the established government be
+  obeyed, and no longer.”—“This principle being admitted, the justice of
+  every particular case of resistance is reduced to a computation of the
+  quantity of the danger and grievance on the one side, and of the
+  probability and expense of redressing it on the other.” Of this, he
+  says, every man shall judge for himself. But Paley appears never to
+  have contemplated those cases to which the rule of expediency does not
+  apply, in which a people, as well as an individual, must do justice,
+  cost what it may. If I have unjustly wrested a plank from a drowning
+  man, I must restore it to him though I drown myself. This, according to
+  Paley, would be inconvenient. But he that would save his life, in such
+  a case, shall lose it. This people must cease to hold slaves, and to
+  make war on Mexico, though it cost them their existence as a people.
+
+  In their practice, nations agree with Paley; but does anyone think that
+  Massachusetts does exactly what is right at the present crisis?
+
+       “A drab of state, a cloth-o’-silver slut,
+       To have her train borne up, and her soul trail in the dirt.”
+
+  Practically speaking, the opponents to a reform in Massachusetts are
+  not a hundred thousand politicians at the South, but a hundred thousand
+  merchants and farmers here, who are more interested in commerce and
+  agriculture than they are in humanity, and are not prepared to do
+  justice to the slave and to Mexico, _cost what it may_. I quarrel not
+  with far-off foes, but with those who, near at home, co-operate with,
+  and do the bidding of those far away, and without whom the latter would
+  be harmless. We are accustomed to say, that the mass of men are
+  unprepared; but improvement is slow, because the few are not materially
+  wiser or better than the many. It is not so important that many should
+  be as good as you, as that there be some absolute goodness somewhere;
+  for that will leaven the whole lump. There are thousands who are _in
+  opinion_ opposed to slavery and to the war, who yet in effect do
+  nothing to put an end to them; who, esteeming themselves children of
+  Washington and Franklin, sit down with their hands in their pockets,
+  and say that they know not what to do, and do nothing; who even
+  postpone the question of freedom to the question of free-trade, and
+  quietly read the prices-current along with the latest advices from
+  Mexico, after dinner, and, it may be, fall asleep over them both. What
+  is the price-current of an honest man and patriot today? They hesitate,
+  and they regret, and sometimes they petition; but they do nothing in
+  earnest and with effect. They will wait, well disposed, for others to
+  remedy the evil, that they may no longer have it to regret. At most,
+  they give only a cheap vote, and a feeble countenance and Godspeed, to
+  the right, as it goes by them. There are nine hundred and ninety-nine
+  patrons of virtue to one virtuous man; but it is easier to deal with
+  the real possessor of a thing than with the temporary guardian of it.
+
+  All voting is a sort of gaming, like chequers or backgammon, with a
+  slight moral tinge to it, a playing with right and wrong, with moral
+  questions; and betting naturally accompanies it. The character of the
+  voters is not staked. I cast my vote, perchance, as I think right; but
+  I am not vitally concerned that that right should prevail. I am willing
+  to leave it to the majority. Its obligation, therefore, never exceeds
+  that of expediency. Even voting _for the right_ is _doing_ nothing for
+  it. It is only expressing to men feebly your desire that it should
+  prevail. A wise man will not leave the right to the mercy of chance,
+  nor wish it to prevail through the power of the majority. There is but
+  little virtue in the action of masses of men. When the majority shall
+  at length vote for the abolition of slavery, it will be because they
+  are indifferent to slavery, or because there is but little slavery left
+  to be abolished by their vote. _They_ will then be the only slaves.
+  Only _his_ vote can hasten the abolition of slavery who asserts his own
+  freedom by his vote.
+
+  I hear of a convention to be held at Baltimore, or elsewhere, for the
+  selection of a candidate for the Presidency, made up chiefly of
+  editors, and men who are politicians by profession; but I think, what
+  is it to any independent, intelligent, and respectable man what
+  decision they may come to, shall we not have the advantage of his
+  wisdom and honesty, nevertheless? Can we not count upon some
+  independent votes? Are there not many individuals in the country who do
+  not attend conventions? But no: I find that the respectable man, so
+  called, has immediately drifted from his position, and despairs of his
+  country, when his country has more reasons to despair of him. He
+  forthwith adopts one of the candidates thus selected as the only
+  _available_ one, thus proving that he is himself _available_ for any
+  purposes of the demagogue. His vote is of no more worth than that of
+  any unprincipled foreigner or hireling native, who may have been
+  bought. Oh for a man who is a _man_, and, as my neighbor says, has a
+  bone in his back which you cannot pass your hand through! Our
+  statistics are at fault: the population has been returned too large.
+  How many _men_ are there to a square thousand miles in the country?
+  Hardly one. Does not America offer any inducement for men to settle
+  here? The American has dwindled into an Odd Fellow,—one who may be
+  known by the development of his organ of gregariousness, and a manifest
+  lack of intellect and cheerful self-reliance; whose first and chief
+  concern, on coming into the world, is to see that the alms-houses are
+  in good repair; and, before yet he has lawfully donned the virile garb,
+  to collect a fund for the support of the widows and orphans that may
+  be; who, in short, ventures to live only by the aid of the Mutual
+  Insurance company, which has promised to bury him decently.
+
+  It is not a man’s duty, as a matter of course, to devote himself to the
+  eradication of any, even the most enormous wrong; he may still properly
+  have other concerns to engage him; but it is his duty, at least, to
+  wash his hands of it, and, if he gives it no thought longer, not to
+  give it practically his support. If I devote myself to other pursuits
+  and contemplations, I must first see, at least, that I do not pursue
+  them sitting upon another man’s shoulders. I must get off him first,
+  that he may pursue his contemplations too. See what gross inconsistency
+  is tolerated. I have heard some of my townsmen say, “I should like to
+  have them order me out to help put down an insurrection of the slaves,
+  or to march to Mexico,—see if I would go;” and yet these very men have
+  each, directly by their allegiance, and so indirectly, at least, by
+  their money, furnished a substitute. The soldier is applauded who
+  refuses to serve in an unjust war by those who do not refuse to sustain
+  the unjust government which makes the war; is applauded by those whose
+  own act and authority he disregards and sets at naught; as if the State
+  were penitent to that degree that it hired one to scourge it while it
+  sinned, but not to that degree that it left off sinning for a moment.
+  Thus, under the name of Order and Civil Government, we are all made at
+  last to pay homage to and support our own meanness. After the first
+  blush of sin, comes its indifference; and from immoral it becomes, as
+  it were, _un_moral, and not quite unnecessary to that life which we
+  have made.
+
+  The broadest and most prevalent error requires the most disinterested
+  virtue to sustain it. The slight reproach to which the virtue of
+  patriotism is commonly liable, the noble are most likely to incur.
+  Those who, while they disapprove of the character and measures of a
+  government, yield to it their allegiance and support, are undoubtedly
+  its most conscientious supporters, and so frequently the most serious
+  obstacles to reform. Some are petitioning the State to dissolve the
+  Union, to disregard the requisitions of the President. Why do they not
+  dissolve it themselves,—the union between themselves and the State,—and
+  refuse to pay their quota into its treasury? Do not they stand in same
+  relation to the State, that the State does to the Union? And have not
+  the same reasons prevented the State from resisting the Union, which
+  have prevented them from resisting the State?
+
+  How can a man be satisfied to entertain an opinion merely, and enjoy
+  _it?_ Is there any enjoyment in it, if his opinion is that he is
+  aggrieved? If you are cheated out of a single dollar by your neighbor,
+  you do not rest satisfied with knowing you are cheated, or with saying
+  that you are cheated, or even with petitioning him to pay you your due;
+  but you take effectual steps at once to obtain the full amount, and see
+  that you are never cheated again. Action from principle,—the perception
+  and the performance of right,—changes things and relations; it is
+  essentially revolutionary, and does not consist wholly with anything
+  which was. It not only divided states and churches, it divides
+  families; aye, it divides the _individual_, separating the diabolical
+  in him from the divine.
+
+  Unjust laws exist: shall we be content to obey them, or shall we
+  endeavor to amend them, and obey them until we have succeeded, or shall
+  we transgress them at once? Men generally, under such a government as
+  this, think that they ought to wait until they have persuaded the
+  majority to alter them. They think that, if they should resist, the
+  remedy would be worse than the evil. But it is the fault of the
+  government itself that the remedy _is_ worse than the evil. _It_ makes
+  it worse. Why is it not more apt to anticipate and provide for reform?
+  Why does it not cherish its wise minority? Why does it cry and resist
+  before it is hurt? Why does it not encourage its citizens to be on the
+  alert to point out its faults, and _do_ better than it would have them?
+  Why does it always crucify Christ, and excommunicate Copernicus and
+  Luther, and pronounce Washington and Franklin rebels?
+
+  One would think, that a deliberate and practical denial of its
+  authority was the only offence never contemplated by government; else,
+  why has it not assigned its definite, its suitable and proportionate
+  penalty? If a man who has no property refuses but once to earn nine
+  shillings for the State, he is put in prison for a period unlimited by
+  any law that I know, and determined only by the discretion of those who
+  placed him there; but if he should steal ninety times nine shillings
+  from the State, he is soon permitted to go at large again.
+
+  If the injustice is part of the necessary friction of the machine of
+  government, let it go, let it go: perchance it will wear
+  smooth,—certainly the machine will wear out. If the injustice has a
+  spring, or a pulley, or a rope, or a crank, exclusively for itself,
+  then perhaps you may consider whether the remedy will not be worse than
+  the evil; but if it is of such a nature that it requires you to be the
+  agent of injustice to another, then, I say, break the law. Let your
+  life be a counter friction to stop the machine. What I have to do is to
+  see, at any rate, that I do not lend myself to the wrong which I
+  condemn.
+
+  As for adopting the ways which the State has provided for remedying the
+  evil, I know not of such ways. They take too much time, and a man’s
+  life will be gone. I have other affairs to attend to. I came into this
+  world, not chiefly to make this a good place to live in, but to live in
+  it, be it good or bad. A man has not every thing to do, but something;
+  and because he cannot do _every thing_, it is not necessary that he
+  should do _something_ wrong. It is not my business to be petitioning
+  the Governor or the Legislature any more than it is theirs to petition
+  me; and, if they should not hear my petition, what should I do then?
+  But in this case the State has provided no way: its very Constitution
+  is the evil. This may seem to be harsh and stubborn and
+  unconcilliatory; but it is to treat with the utmost kindness and
+  consideration the only spirit that can appreciate or deserves it. So is
+  all change for the better, like birth and death which convulse the
+  body.
+
+  I do not hesitate to say, that those who call themselves abolitionists
+  should at once effectually withdraw their support, both in person and
+  property, from the government of Massachusetts, and not wait till they
+  constitute a majority of one, before they suffer the right to prevail
+  through them. I think that it is enough if they have God on their side,
+  without waiting for that other one. Moreover, any man more right than
+  his neighbors constitutes a majority of one already.
+
+  I meet this American government, or its representative, the State
+  government, directly, and face to face, once a year, no more, in the
+  person of its tax-gatherer; this is the only mode in which a man
+  situated as I am necessarily meets it; and it then says distinctly,
+  Recognize me; and the simplest, the most effectual, and, in the present
+  posture of affairs, the indispensablest mode of treating with it on
+  this head, of expressing your little satisfaction with and love for it,
+  is to deny it then. My civil neighbor, the tax-gatherer, is the very
+  man I have to deal with,—for it is, after all, with men and not with
+  parchment that I quarrel,—and he has voluntarily chosen to be an agent
+  of the government. How shall he ever know well what he is and does as
+  an officer of the government, or as a man, until he is obliged to
+  consider whether he shall treat me, his neighbor, for whom he has
+  respect, as a neighbor and well-disposed man, or as a maniac and
+  disturber of the peace, and see if he can get over this obstruction to
+  his neighborliness without a ruder and more impetuous thought or speech
+  corresponding with his action? I know this well, that if one thousand,
+  if one hundred, if ten men whom I could name,—if ten _honest_ men
+  only,—aye, if _one_ HONEST man, in this State of Massachusetts,
+  _ceasing to hold slaves_, were actually to withdraw from this
+  copartnership, and be locked up in the county jail therefor, it would
+  be the abolition of slavery in America. For it matters not how small
+  the beginning may seem to be: what is once well done is done for ever.
+  But we love better to talk about it: that we say is our mission. Reform
+  keeps many scores of newspapers in its service, but not one man. If my
+  esteemed neighbor, the State’s ambassador, who will devote his days to
+  the settlement of the question of human rights in the Council Chamber,
+  instead of being threatened with the prisons of Carolina, were to sit
+  down the prisoner of Massachusetts, that State which is so anxious to
+  foist the sin of slavery upon her sister,—though at present she can
+  discover only an act of inhospitality to be the ground of a quarrel
+  with her,—the Legislature would not wholly waive the subject of the
+  following winter.
+
+  Under a government which imprisons any unjustly, the true place for a
+  just man is also a prison. The proper place today, the only place which
+  Massachusetts has provided for her freer and less desponding spirits,
+  is in her prisons, to be put out and locked out of the State by her own
+  act, as they have already put themselves out by their principles. It is
+  there that the fugitive slave, and the Mexican prisoner on parole, and
+  the Indian come to plead the wrongs of his race, should find them; on
+  that separate, but more free and honorable ground, where the State
+  places those who are not _with_ her but _against_ her,—the only house
+  in a slave-state in which a free man can abide with honor. If any think
+  that their influence would be lost there, and their voices no longer
+  afflict the ear of the State, that they would not be as an enemy within
+  its walls, they do not know by how much truth is stronger than error,
+  nor how much more eloquently and effectively he can combat injustice
+  who has experienced a little in his own person. Cast your whole vote,
+  not a strip of paper merely, but your whole influence. A minority is
+  powerless while it conforms to the majority; it is not even a minority
+  then; but it is irresistible when it clogs by its whole weight. If the
+  alternative is to keep all just men in prison, or give up war and
+  slavery, the State will not hesitate which to choose. If a thousand men
+  were not to pay their tax-bills this year, that would not be a violent
+  and bloody measure, as it would be to pay them, and enable the State to
+  commit violence and shed innocent blood. This is, in fact, the
+  definition of a peaceable revolution, if any such is possible. If the
+  tax-gatherer, or any other public officer, asks me, as one has done,
+  “But what shall I do?” my answer is, “If you really wish to do any
+  thing, resign your office.” When the subject has refused allegiance,
+  and the officer has resigned his office, then the revolution is
+  accomplished. But even suppose blood should flow. Is there not a sort
+  of blood shed when the conscience is wounded? Through this wound a
+  man’s real manhood and immortality flow out, and he bleeds to an
+  everlasting death. I see this blood flowing now.
+
+  I have contemplated the imprisonment of the offender, rather than the
+  seizure of his goods,—though both will serve the same purpose,—because
+  they who assert the purest right, and consequently are most dangerous
+  to a corrupt State, commonly have not spent much time in accumulating
+  property. To such the State renders comparatively small service, and a
+  slight tax is wont to appear exorbitant, particularly if they are
+  obliged to earn it by special labor with their hands. If there were one
+  who lived wholly without the use of money, the State itself would
+  hesitate to demand it of him. But the rich man—not to make any
+  invidious comparison—is always sold to the institution which makes him
+  rich. Absolutely speaking, the more money, the less virtue; for money
+  comes between a man and his objects, and obtains them for him; it was
+  certainly no great virtue to obtain it. It puts to rest many questions
+  which he would otherwise be taxed to answer; while the only new
+  question which it puts is the hard but superfluous one, how to spend
+  it. Thus his moral ground is taken from under his feet. The
+  opportunities of living are diminished in proportion as what are called
+  the “means” are increased. The best thing a man can do for his culture
+  when he is rich is to endeavor to carry out those schemes which he
+  entertained when he was poor. Christ answered the Herodians according
+  to their condition. “Show me the tribute-money,” said he;—and one took
+  a penny out of his pocket;—if you use money which has the image of
+  Cæsar on it, and which he has made current and valuable, that is, _if
+  you are men of the State_, and gladly enjoy the advantages of Cæsar’s
+  government, then pay him back some of his own when he demands it;
+  “Render therefore to Cæsar that which is Cæsar’s and to God those
+  things which are God’s,”—leaving them no wiser than before as to which
+  was which; for they did not wish to know.
+
+  When I converse with the freest of my neighbors, I perceive that,
+  whatever they may say about the magnitude and seriousness of the
+  question, and their regard for the public tranquillity, the long and
+  the short of the matter is, that they cannot spare the protection of
+  the existing government, and they dread the consequences of
+  disobedience to it to their property and families. For my own part, I
+  should not like to think that I ever rely on the protection of the
+  State. But, if I deny the authority of the State when it presents its
+  tax-bill, it will soon take and waste all my property, and so harass me
+  and my children without end. This is hard. This makes it impossible for
+  a man to live honestly and at the same time comfortably in outward
+  respects. It will not be worth the while to accumulate property; that
+  would be sure to go again. You must hire or squat somewhere, and raise
+  but a small crop, and eat that soon. You must live within yourself, and
+  depend upon yourself, always tucked up and ready for a start, and not
+  have many affairs. A man may grow rich in Turkey even, if he will be in
+  all respects a good subject of the Turkish government. Confucius
+  said,—“If a State is governed by the principles of reason, poverty and
+  misery are subjects of shame; if a State is not governed by the
+  principles of reason, riches and honors are the subjects of shame.” No:
+  until I want the protection of Massachusetts to be extended to me in
+  some distant southern port, where my liberty is endangered, or until I
+  am bent solely on building up an estate at home by peaceful enterprise,
+  I can afford to refuse allegiance to Massachusetts, and her right to my
+  property and life. It costs me less in every sense to incur the penalty
+  of disobedience to the State, than it would to obey. I should feel as
+  if I were worth less in that case.
+
+  Some years ago, the State met me in behalf of the church, and commanded
+  me to pay a certain sum toward the support of a clergyman whose
+  preaching my father attended, but never I myself. “Pay it,” it said,
+  “or be locked up in the jail.” I declined to pay. But, unfortunately,
+  another man saw fit to pay it. I did not see why the schoolmaster
+  should be taxed to support the priest, and not the priest the
+  schoolmaster; for I was not the State’s schoolmaster, but I supported
+  myself by voluntary subscription. I did not see why the lyceum should
+  not present its tax-bill, and have the State to back its demand, as
+  well as the church. However, at the request of the selectmen, I
+  condescended to make some such statement as this in writing:—“Know all
+  men by these presents, that I, Henry Thoreau, do not wish to be
+  regarded as a member of any incorporated society which I have not
+  joined.” This I gave to the town-clerk; and he has it. The State,
+  having thus learned that I did not wish to be regarded as a member of
+  that church, has never made a like demand on me since; though it said
+  that it must adhere to its original presumption that time. If I had
+  known how to name them, I should then have signed off in detail from
+  all the societies which I never signed on to; but I did not know where
+  to find such a complete list.
+
+  I have paid no poll-tax for six years. I was put into a jail once on
+  this account, for one night; and, as I stood considering the walls of
+  solid stone, two or three feet thick, the door of wood and iron, a foot
+  thick, and the iron grating which strained the light, I could not help
+  being struck with the foolishness of that institution which treated me
+  as if I were mere flesh and blood and bones, to be locked up. I
+  wondered that it should have concluded at length that this was the best
+  use it could put me to, and had never thought to avail itself of my
+  services in some way. I saw that, if there was a wall of stone between
+  me and my townsmen, there was a still more difficult one to climb or
+  break through, before they could get to be as free as I was. I did nor
+  for a moment feel confined, and the walls seemed a great waste of stone
+  and mortar. I felt as if I alone of all my townsmen had paid my tax.
+  They plainly did not know how to treat me, but behaved like persons who
+  are underbred. In every threat and in every compliment there was a
+  blunder; for they thought that my chief desire was to stand the other
+  side of that stone wall. I could not but smile to see how industriously
+  they locked the door on my meditations, which followed them out again
+  without let or hindrance, and _they_ were really all that was
+  dangerous. As they could not reach me, they had resolved to punish my
+  body; just as boys, if they cannot come at some person against whom
+  they have a spite, will abuse his dog. I saw that the State was
+  half-witted, that it was timid as a lone woman with her silver spoons,
+  and that it did not know its friends from its foes, and I lost all my
+  remaining respect for it, and pitied it.
+
+  Thus the state never intentionally confronts a man’s sense,
+  intellectual or moral, but only his body, his senses. It is not armed
+  with superior wit or honesty, but with superior physical strength. I
+  was not born to be forced. I will breathe after my own fashion. Let us
+  see who is the strongest. What force has a multitude? They only can
+  force me who obey a higher law than I. They force me to become like
+  themselves. I do not hear of _men_ being _forced_ to live this way or
+  that by masses of men. What sort of life were that to live? When I meet
+  a government which says to me, “Your money or your life,” why should I
+  be in haste to give it my money? It may be in a great strait, and not
+  know what to do: I cannot help that. It must help itself; do as I do.
+  It is not worth the while to snivel about it. I am not responsible for
+  the successful working of the machinery of society. I am not the son of
+  the engineer. I perceive that, when an acorn and a chestnut fall side
+  by side, the one does not remain inert to make way for the other, but
+  both obey their own laws, and spring and grow and flourish as best they
+  can, till one, perchance, overshadows and destroys the other. If a
+  plant cannot live according to its nature, it dies; and so a man.
+
+
+
+  The night in prison was novel and interesting enough. The prisoners in
+  their shirt-sleeves were enjoying a chat and the evening air in the
+  door-way, when I entered. But the jailer said, “Come, boys, it is time
+  to lock up;” and so they dispersed, and I heard the sound of their
+  steps returning into the hollow apartments. My room-mate was introduced
+  to me by the jailer as “a first-rate fellow and a clever man.” When the
+  door was locked, he showed me where to hang my hat, and how he managed
+  matters there. The rooms were whitewashed once a month; and this one,
+  at least, was the whitest, most simply furnished, and probably the
+  neatest apartment in town. He naturally wanted to know where I came
+  from, and what brought me there; and, when I had told him, I asked him
+  in my turn how he came there, presuming him to be an honest man, of
+  course; and, as the world goes, I believe he was. “Why,” said he, “they
+  accuse me of burning a barn; but I never did it.” As near as I could
+  discover, he had probably gone to bed in a barn when drunk, and smoked
+  his pipe there; and so a barn was burnt. He had the reputation of being
+  a clever man, had been there some three months waiting for his trial to
+  come on, and would have to wait as much longer; but he was quite
+  domesticated and contented, since he got his board for nothing, and
+  thought that he was well treated.
+
+  He occupied one window, and I the other; and I saw, that, if one stayed
+  there long, his principal business would be to look out the window. I
+  had soon read all the tracts that were left there, and examined where
+  former prisoners had broken out, and where a grate had been sawed off,
+  and heard the history of the various occupants of that room; for I
+  found that even here there was a history and a gossip which never
+  circulated beyond the walls of the jail. Probably this is the only
+  house in the town where verses are composed, which are afterward
+  printed in a circular form, but not published. I was shown quite a long
+  list of verses which were composed by some young men who had been
+  detected in an attempt to escape, who avenged themselves by singing
+  them.
+
+  I pumped my fellow-prisoner as dry as I could, for fear I should never
+  see him again; but at length he showed me which was my bed, and left me
+  to blow out the lamp.
+
+  It was like travelling into a far country, such as I had never expected
+  to behold, to lie there for one night. It seemed to me that I never had
+  heard the town-clock strike before, nor the evening sounds of the
+  village; for we slept with the windows open, which were inside the
+  grating. It was to see my native village in the light of the Middle
+  Ages, and our Concord was turned into a Rhine stream, and visions of
+  knights and castles passed before me. They were the voices of old
+  burghers that I heard in the streets. I was an involuntary spectator
+  and auditor of whatever was done and said in the kitchen of the
+  adjacent village-inn—a wholly new and rare experience to me. It was a
+  closer view of my native town. I was fairly inside of it. I never had
+  seen its institutions before. This is one of its peculiar institutions;
+  for it is a shire town. I began to comprehend what its inhabitants were
+  about.
+
+  In the morning, our breakfasts were put through the hole in the door,
+  in small oblong-square tin pans, made to fit, and holding a pint of
+  chocolate, with brown bread, and an iron spoon. When they called for
+  the vessels again, I was green enough to return what bread I had left;
+  but my comrade seized it, and said that I should lay that up for lunch
+  or dinner. Soon after, he was let out to work at haying in a
+  neighboring field, whither he went every day, and would not be back
+  till noon; so he bade me good-day, saying that he doubted if he should
+  see me again.
+
+  When I came out of prison,—for some one interfered, and paid the tax,—I
+  did not perceive that great changes had taken place on the common, such
+  as he observed who went in a youth, and emerged a gray-headed man; and
+  yet a change had to my eyes come over the scene,—the town, and State,
+  and country,—greater than any that mere time could effect. I saw yet
+  more distinctly the State in which I lived. I saw to what extent the
+  people among whom I lived could be trusted as good neighbors and
+  friends; that their friendship was for summer weather only; that they
+  did not greatly purpose to do right; that they were a distinct race
+  from me by their prejudices and superstitions, as the Chinamen and
+  Malays are; that, in their sacrifices to humanity they ran no risks,
+  not even to their property; that, after all, they were not so noble but
+  they treated the thief as he had treated them, and hoped, by a certain
+  outward observance and a few prayers, and by walking in a particular
+  straight though useless path from time to time, to save their souls.
+  This may be to judge my neighbors harshly; for I believe that most of
+  them are not aware that they have such an institution as the jail in
+  their village.
+
+  It was formerly the custom in our village, when a poor debtor came out
+  of jail, for his acquaintances to salute him, looking through their
+  fingers, which were crossed to represent the grating of a jail window,
+  “How do ye do?” My neighbors did not thus salute me, but first looked
+  at me, and then at one another, as if I had returned from a long
+  journey. I was put into jail as I was going to the shoemaker’s to get a
+  shoe which was mended. When I was let out the next morning, I proceeded
+  to finish my errand, and, having put on my mended shoe, joined a
+  huckleberry party, who were impatient to put themselves under my
+  conduct; and in half an hour,—for the horse was soon tackled,—was in
+  the midst of a huckleberry field, on one of our highest hills, two
+  miles off; and then the State was nowhere to be seen.
+
+  This is the whole history of “My Prisons.”
+
+
+
+  I have never declined paying the highway tax, because I am as desirous
+  of being a good neighbor as I am of being a bad subject; and, as for
+  supporting schools, I am doing my part to educate my fellow-countrymen
+  now. It is for no particular item in the tax-bill that I refuse to pay
+  it. I simply wish to refuse allegiance to the State, to withdraw and
+  stand aloof from it effectually. I do not care to trace the course of
+  my dollar, if I could, till it buys a man, or a musket to shoot one
+  with,—the dollar is innocent,—but I am concerned to trace the effects
+  of my allegiance. In fact, I quietly declare war with the State, after
+  my fashion, though I will still make use and get what advantages of her
+  I can, as is usual in such cases.
+
+  If others pay the tax which is demanded of me, from a sympathy with the
+  State, they do but what they have already done in their own case, or
+  rather they abet injustice to a greater extent than the State requires.
+  If they pay the tax from a mistaken interest in the individual taxed,
+  to save his property or prevent his going to jail, it is because they
+  have not considered wisely how far they let their private feelings
+  interfere with the public good.
+
+  This, then, is my position at present. But one cannot be too much on
+  his guard in such a case, lest his actions be biassed by obstinacy, or
+  an undue regard for the opinions of men. Let him see that he does only
+  what belongs to himself and to the hour.
+
+  I think sometimes, Why, this people mean well; they are only ignorant;
+  they would do better if they knew how: why give your neighbors this
+  pain to treat you as they are not inclined to? But I think, again, this
+  is no reason why I should do as they do, or permit others to suffer
+  much greater pain of a different kind. Again, I sometimes say to
+  myself, When many millions of men, without heat, without ill-will,
+  without personal feeling of any kind, demand of you a few shillings
+  only, without the possibility, such is their constitution, of
+  retracting or altering their present demand, and without the
+  possibility, on your side, of appeal to any other millions, why expose
+  yourself to this overwhelming brute force? You do not resist cold and
+  hunger, the winds and the waves, thus obstinately; you quietly submit
+  to a thousand similar necessities. You do not put your head into the
+  fire. But just in proportion as I regard this as not wholly a brute
+  force, but partly a human force, and consider that I have relations to
+  those millions as to so many millions of men, and not of mere brute or
+  inanimate things, I see that appeal is possible, first and
+  instantaneously, from them to the Maker of them, and, secondly, from
+  them to themselves. But, if I put my head deliberately into the fire,
+  there is no appeal to fire or to the Maker of fire, and I have only
+  myself to blame. If I could convince myself that I have any right to be
+  satisfied with men as they are, and to treat them accordingly, and not
+  according, in some respects, to my requisitions and expectations of
+  what they and I ought to be, then, like a good Mussulman and fatalist,
+  I should endeavor to be satisfied with things as they are, and say it
+  is the will of God. And, above all, there is this difference between
+  resisting this and a purely brute or natural force, that I can resist
+  this with some effect; but I cannot expect, like Orpheus, to change the
+  nature of the rocks and trees and beasts.
+
+  I do not wish to quarrel with any man or nation. I do not wish to split
+  hairs, to make fine distinctions, or set myself up as better than my
+  neighbors. I seek rather, I may say, even an excuse for conforming to
+  the laws of the land. I am but too ready to conform to them. Indeed I
+  have reason to suspect myself on this head; and each year, as the
+  tax-gatherer comes round, I find myself disposed to review the acts and
+  position of the general and state governments, and the spirit of the
+  people to discover a pretext for conformity.
+
+       “We must affect our country as our parents,
+       And if at any time we alienate
+       Out love of industry from doing it honor,
+       We must respect effects and teach the soul
+       Matter of conscience and religion,
+       And not desire of rule or benefit.”
+
+  I believe that the State will soon be able to take all my work of this
+  sort out of my hands, and then I shall be no better patriot than my
+  fellow-countrymen. Seen from a lower point of view, the Constitution,
+  with all its faults, is very good; the law and the courts are very
+  respectable; even this State and this American government are, in many
+  respects, very admirable, and rare things, to be thankful for, such as
+  a great many have described them; seen from a higher still, and the
+  highest, who shall say what they are, or that they are worth looking at
+  or thinking of at all?
+
+  However, the government does not concern me much, and I shall bestow
+  the fewest possible thoughts on it. It is not many moments that I live
+  under a government, even in this world. If a man is thought-free,
+  fancy-free, imagination-free, that which _is not_ never for a long time
+  appearing _to be_ to him, unwise rulers or reformers cannot fatally
+  interrupt him.
+
+  I know that most men think differently from myself; but those whose
+  lives are by profession devoted to the study of these or kindred
+  subjects content me as little as any. Statesmen and legislators,
+  standing so completely within the institution, never distinctly and
+  nakedly behold it. They speak of moving society, but have no
+  resting-place without it. They may be men of a certain experience and
+  discrimination, and have no doubt invented ingenious and even useful
+  systems, for which we sincerely thank them; but all their wit and
+  usefulness lie within certain not very wide limits. They are wont to
+  forget that the world is not governed by policy and expediency. Webster
+  never goes behind government, and so cannot speak with authority about
+  it. His words are wisdom to those legislators who contemplate no
+  essential reform in the existing government; but for thinkers, and
+  those who legislate for all time, he never once glances at the subject.
+  I know of those whose serene and wise speculations on this theme would
+  soon reveal the limits of his mind’s range and hospitality. Yet,
+  compared with the cheap professions of most reformers, and the still
+  cheaper wisdom and eloquence of politicians in general, his are almost
+  the only sensible and valuable words, and we thank Heaven for him.
+  Comparatively, he is always strong, original, and, above all,
+  practical. Still his quality is not wisdom, but prudence. The lawyer’s
+  truth is not Truth, but consistency or a consistent expediency. Truth
+  is always in harmony with herself, and is not concerned chiefly to
+  reveal the justice that may consist with wrong-doing. He well deserves
+  to be called, as he has been called, the Defender of the Constitution.
+  There are really no blows to be given by him but defensive ones. He is
+  not a leader, but a follower. His leaders are the men of ’87. “I have
+  never made an effort,” he says, “and never propose to make an effort; I
+  have never countenanced an effort, and never mean to countenance an
+  effort, to disturb the arrangement as originally made, by which the
+  various States came into the Union.” Still thinking of the sanction
+  which the Constitution gives to slavery, he says, “Because it was part
+  of the original compact,—let it stand.” Notwithstanding his special
+  acuteness and ability, he is unable to take a fact out of its merely
+  political relations, and behold it as it lies absolutely to be disposed
+  of by the intellect,—what, for instance, it behoves a man to do here in
+  America today with regard to slavery, but ventures, or is driven, to
+  make some such desperate answer as the following, while professing to
+  speak absolutely, and as a private man,—from which what new and
+  singular code of social duties might be inferred?—“The manner,” says
+  he, “in which the governments of those States where slavery exists are
+  to regulate it, is for their own consideration, under the
+  responsibility to their constituents, to the general laws of propriety,
+  humanity, and justice, and to God. Associations formed elsewhere,
+  springing from a feeling of humanity, or any other cause, have nothing
+  whatever to do with it. They have never received any encouragement from
+  me and they never will.”
+
+  They who know of no purer sources of truth, who have traced up its
+  stream no higher, stand, and wisely stand, by the Bible and the
+  Constitution, and drink at it there with reverence and humanity; but
+  they who behold where it comes trickling into this lake or that pool,
+  gird up their loins once more, and continue their pilgrimage toward its
+  fountain-head.
+
+  No man with a genius for legislation has appeared in America. They are
+  rare in the history of the world. There are orators, politicians, and
+  eloquent men, by the thousand; but the speaker has not yet opened his
+  mouth to speak who is capable of settling the much-vexed questions of
+  the day. We love eloquence for its own sake, and not for any truth
+  which it may utter, or any heroism it may inspire. Our legislators have
+  not yet learned the comparative value of free-trade and of freedom, of
+  union, and of rectitude, to a nation. They have no genius or talent for
+  comparatively humble questions of taxation and finance, commerce and
+  manufactures and agriculture. If we were left solely to the wordy wit
+  of legislators in Congress for our guidance, uncorrected by the
+  seasonable experience and the effectual complaints of the people,
+  America would not long retain her rank among the nations. For eighteen
+  hundred years, though perchance I have no right to say it, the New
+  Testament has been written; yet where is the legislator who has wisdom
+  and practical talent enough to avail himself of the light which it
+  sheds on the science of legislation.
+
+  The authority of government, even such as I am willing to submit
+  to,—for I will cheerfully obey those who know and can do better than I,
+  and in many things even those who neither know nor can do so well,—is
+  still an impure one: to be strictly just, it must have the sanction and
+  consent of the governed. It can have no pure right over my person and
+  property but what I concede to it. The progress from an absolute to a
+  limited monarchy, from a limited monarchy to a democracy, is a progress
+  toward a true respect for the individual. Even the Chinese philosopher
+  was wise enough to regard the individual as the basis of the empire. Is
+  a democracy, such as we know it, the last improvement possible in
+  government? Is it not possible to take a step further towards
+  recognizing and organizing the rights of man? There will never be a
+  really free and enlightened State, until the State comes to recognize
+  the individual as a higher and independent power, from which all its
+  own power and authority are derived, and treats him accordingly. I
+  please myself with imagining a State at last which can afford to be
+  just to all men, and to treat the individual with respect as a
+  neighbor; which even would not think it inconsistent with its own
+  repose, if a few were to live aloof from it, not meddling with it, nor
+  embraced by it, who fulfilled all the duties of neighbors and
+  fellow-men. A State which bore this kind of fruit, and suffered it to
+  drop off as fast as it ripened, would prepare the way for a still more
+  perfect and glorious State, which also I have imagined, but not yet
+  anywhere seen.

--- a/spec/odyssey/formulas/ari_spec.rb
+++ b/spec/odyssey/formulas/ari_spec.rb
@@ -1,27 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'Automated Readability Index' do
+fixture_texts.each do |text|
+  context 'Automated Readability Index' do
+    describe '.ari' do
+      subject { Odyssey.ari text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.ari one_simple_sentence
-      @double = Odyssey.ari two_simple_sentences
-      @complex = Odyssey.ari one_complex_sentence
-      @complex_double = Odyssey.ari two_complex_sentences
-      @very_complex = Odyssey.ari very_complex
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      @simple.should == -4.2
-      @double.should == -3.4
-      @complex.should == 1.4
-      @complex_double.should == 2.8
-      @very_complex.should == 12.1
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:ari]
+      end
     end
   end
-
 end

--- a/spec/odyssey/formulas/coleman_liau_spec.rb
+++ b/spec/odyssey/formulas/coleman_liau_spec.rb
@@ -1,28 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'Coleman-Liau Index' do
+fixture_texts.each do |text|
+  context 'Coleman-Liau Index' do
+    describe '.coleman_liau ' do
+      subject { Odyssey.coleman_liau text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.coleman_liau one_simple_sentence
-      @double = Odyssey.coleman_liau two_simple_sentences
-      @complex = Odyssey.coleman_liau one_complex_sentence
-      @complex_double = Odyssey.coleman_liau two_complex_sentences
-      @very_complex = Odyssey.coleman_liau very_complex
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      @simple.should == 3.7
-      @double.should == 4.7
-      @complex.should == 7.1
-      @complex_double.should == 9.1
-      @very_complex.should == 10.7
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:coleman_liau]
+      end
     end
   end
-
 end
-

--- a/spec/odyssey/formulas/flesch_kincaid_gl_spec.rb
+++ b/spec/odyssey/formulas/flesch_kincaid_gl_spec.rb
@@ -1,25 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'Flesch-Kincaid Grade Level' do
+fixture_texts.each do |text|
+  context 'Flesch-Kincaid Grade Level' do
+    describe '.flesch_kincaid_gl' do
+      subject { Odyssey.flesch_kincaid_gl text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.flesch_kincaid_gl one_simple_sentence
-      @double = Odyssey.flesch_kincaid_gl two_simple_sentences
-      @complex = Odyssey.flesch_kincaid_gl one_complex_sentence
-      @complex_double = Odyssey.flesch_kincaid_gl two_complex_sentences
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      @simple.should == -2.6
-      @double.should == -2.6
-      @complex.should == 2.3
-      @complex_double.should == 3
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:flesch_kincaid_grade_level]
+      end
     end
   end
-
 end

--- a/spec/odyssey/formulas/flesch_kincaid_re_spec.rb
+++ b/spec/odyssey/formulas/flesch_kincaid_re_spec.rb
@@ -1,25 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'Flesch-Kincaid Reading Ease' do
+fixture_texts.each do |text|
+  context 'Flesch-Kincaid Reading Ease' do
+    describe '.flesch_kincaid_re' do
+      subject { Odyssey.flesch_kincaid_re text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.flesch_kincaid_re one_simple_sentence
-      @double = Odyssey.flesch_kincaid_re two_simple_sentences
-      @complex = Odyssey.flesch_kincaid_re one_complex_sentence
-      @complex_double = Odyssey.flesch_kincaid_re two_complex_sentences
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      @simple.should == 119.2
-      @double.should == 119.2
-      @complex.should == 94.3
-      @complex_double.should == 88.7
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:flesch_kincaid_reading_ease]
+      end
     end
   end
-
 end

--- a/spec/odyssey/formulas/gunning_fog_spec.rb
+++ b/spec/odyssey/formulas/gunning_fog_spec.rb
@@ -1,25 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'Gunning-Fog Score' do
+fixture_texts.each do |text|
+  context 'Gunning-Fog Score' do
+    describe '.gunning_fog' do
+      subject { Odyssey.gunning_fog text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.gunning_fog one_simple_sentence
-      @double = Odyssey.gunning_fog two_simple_sentences
-      @complex = Odyssey.gunning_fog one_complex_sentence
-      @complex_double = Odyssey.gunning_fog two_complex_sentences
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      @simple.should == 1.2
-      @double.should == 1.2
-      @complex.should == 3.6
-      @complex_double.should == 3.4
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:gunning_fog]
+      end
     end
   end
-
 end

--- a/spec/odyssey/formulas/smog_spec.rb
+++ b/spec/odyssey/formulas/smog_spec.rb
@@ -1,27 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-context 'SMOG Index' do
+fixture_texts.each do |text|
+  context 'SMOG Index' do
+    describe '.smog' do
+      subject { Odyssey.smog text[:text] }
 
-  describe 'get score' do
-    before :all do
-      @simple = Odyssey.smog one_simple_sentence
-      @double = Odyssey.smog two_simple_sentences
-      @complex = Odyssey.smog one_complex_sentence
-      @complex_double = Odyssey.smog two_complex_sentences
-      @very_complex = Odyssey.smog very_complex
-    end
+      it { is_expected.to_not eq nil }
 
-    it 'should return something' do
-      @simple.should_not be_nil
-    end
-
-    it 'should return the score' do
-      # @simple.should == 1.8
-      # @double.should == 1.8
-      # @complex.should == 1.8
-      # @complex_double.should == 1.8
-      # @very_complex.should == 10.1
+      it 'should return the score' do
+        expect(subject).to eq text[:scores][:smog]
+      end
     end
   end
-
 end

--- a/spec/odyssey/refinements_spec.rb
+++ b/spec/odyssey/refinements_spec.rb
@@ -5,9 +5,11 @@ using Odyssey::Refinements
 describe Odyssey::Refinements do
   describe String do
     describe '#readability' do
+      let(:simple_sentence) { 'This is an example sentence.' }
+
       it "calls Odyssey#analyze_all" do
-        expect(Odyssey).to receive(:analyze_all).with(one_simple_sentence)
-        one_simple_sentence.readability
+        expect(Odyssey).to receive(:analyze_all).with(simple_sentence)
+        simple_sentence.readability
       end
     end
   end

--- a/spec/odyssey_spec.rb
+++ b/spec/odyssey_spec.rb
@@ -1,171 +1,245 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Odyssey do
+  fixture_texts.each do |text|
+    describe '.analyze' do
+      context 'with no args' do
+        subject { Odyssey.analyze text[:text] }
 
-  context 'default formula' do
-    it 'should return something' do
-      result = Odyssey.analyze one_simple_sentence
-      result.should_not be_nil
-    end
-
-    describe 'get all stats' do
-      before :all do
-        @simple = Odyssey.analyze one_simple_sentence, nil, true
-        @double = Odyssey.analyze two_simple_sentences, nil, true
+        it 'outputs the FleschKincaid Reading Ease score' do
+          expect(subject).to eq text[:scores][:flesch_kincaid_reading_ease]
+        end
       end
 
-      it 'should return formula name' do
-        @simple['name'].should == 'Flesch-Kincaid Reading Ease'
-      end
+      context 'with no formulas provided, and `all_stats = true`' do
+        subject { Odyssey.analyze text[:text], nil, true }
 
-      it 'should return score' do
-        @simple['score'].should == 119.2
-      end
+        describe "['name']" do
+          it 'returns formula name' do
+            expect(subject['name']).to eq 'Flesch-Kincaid Reading Ease'
+          end
+        end
 
-      it 'should return the formula' do
-        @simple['formula'].class.to_s.should == 'FleschKincaidRe'
-      end
+        describe "['score']" do
+          it 'returns the score' do
+            expect(subject['score']).to \
+              eq text[:scores][:flesch_kincaid_reading_ease]
+          end
+        end
 
-      it 'should return string length' do
-        @simple['string_length'].should == 13
-      end
+        describe "['formula']" do
+          it 'returns the formula class' do
+            expect(subject['formula'].class.to_s).to eq 'FleschKincaidRe'
+          end
+        end
 
-      it 'should return letter count' do
-        @simple['letter_count'].should == 10
-      end
+        describe "['string_length']" do
+          it 'returns the number of characters (including whitespace)' do
+            expect(subject['string_length']).to \
+              eq text[:data][:string_length]
+          end
+        end
 
-      it 'should return syllable count' do
-        @simple['syllable_count'].should == 3
-      end
+        describe "['letter_count']" do
+          it 'returns the number of letters' do
+            expect(subject['letter_count']).to eq text[:data][:letter_count]
+          end
+        end
 
-      it 'should return word count' do
-        @simple['word_count'].should == 3
+        describe "['syllable_count']" do
+          it 'returns the number of syllables' do
+            expect(subject['syllable_count']).to \
+              eq text[:data][:syllable_count]
+          end
+        end
 
-        @double['word_count'].should == 6
-      end
+        describe "['word_count']" do
+          it 'returns the number of words' do
+            expect(subject['word_count']).to eq text[:data][:word_count]
+          end
+        end
 
-      it 'should return sentence count' do
-        @simple['sentence_count'].should == 1
+        describe "['sentence_count']" do
+          it 'returns the number of sentences' do
+            expect(subject['sentence_count']).to \
+              eq text[:data][:sentence_count]
+          end
+        end
 
-        @double['sentence_count'].should == 2
-      end
+        describe "['average_words_per_sentence']" do
+          it 'returns the average words per sentences' do
+            expect(subject['average_words_per_sentence']).to \
+              eq text[:data][:average_words_per_sentence]
+          end
+        end
 
-      it 'should return average words per sentence' do
-        @simple['average_words_per_sentence'].should == 3
-
-        @double['average_words_per_sentence'].should == 3
-      end
-
-      it 'should return average syllables per word' do
-        @simple['average_syllables_per_word'].should == 1
-
-        @double['average_syllables_per_word'].should == 1
-      end
-
-    end
-  end
-
-  context 'Run multiple formulas' do
-
-    describe 'get scores' do
-      before :all do
-        formula_names = [ 'Ari',
-                          'ColemanLiau',
-                          'FleschKincaidGl',
-                          'FleschKincaidRe',
-                          'GunningFog']
-
-        @simple = Odyssey.analyze_multi one_simple_sentence, formula_names
-        @simple_stats = Odyssey.analyze_multi one_simple_sentence, formula_names, true
-      end
-
-      it 'should return something' do
-        @simple.should_not be_nil
-      end
-
-      it 'should return the scores' do
-        @simple['Ari'].should             == -4.2
-        @simple['ColemanLiau'].should     == 3.7
-        @simple['FleschKincaidGl'].should == -2.6
-        @simple['FleschKincaidRe'].should == 119.2
-        @simple['GunningFog'].should      == 1.2
-      end
-
-      it 'should return correct stats' do
-        @simple_stats['string_length'].should  == 13
-        @simple_stats['letter_count'].should   == 10
-        @simple_stats['syllable_count'].should == 3
-        @simple_stats['word_count'].should     == 3
-        @simple_stats['sentence_count'].should == 1
-        @simple_stats['average_words_per_sentence'].should == 3
-        @simple_stats['average_syllables_per_word'].should == 1
-      end
-
-      it 'should include scores in the stats hash' do
-        @simple_stats['scores']['Ari'].should             == -4.2
-        @simple_stats['scores']['ColemanLiau'].should     == 3.7
-        @simple_stats['scores']['FleschKincaidGl'].should == -2.6
-        @simple_stats['scores']['FleschKincaidRe'].should == 119.2
-        @simple_stats['scores']['GunningFog'].should      == 1.2
-      end
-
-      it 'should not include score in the stats hash' do
-        @simple_stats['name'].should    be_nil
-        @simple_stats['formula'].should be_nil
-        @simple_stats['score'].should   be_nil
+        describe "['average_syllables_per_word']" do
+          it 'returns the average syllables per word' do
+            expect(subject['average_syllables_per_word']).to \
+              eq text[:data][:average_syllables_per_word]
+          end
+        end
       end
     end
 
-    it 'should raise an error for empty formula list' do
-      expect { Odyssey.analyze_multi one_simple_sentence, [] }.to raise_error(ArgumentError)
-    end
-  end
+    describe '.analyze_multi' do
+      context 'with multiple formulas provided, and `all_stats = true`' do
+        let :scores do
+          %w[
+            Ari
+            ColemanLiau
+            FleschKincaidGl
+            FleschKincaidRe
+            GunningFog
+            Smog
+          ]
+        end
+        subject { Odyssey.analyze_multi text[:text], scores, true }
 
-  context 'Run all formulas' do
-    describe 'get scores' do
+        describe "['FormulaClass']" do
+          it 'returns the score' do
+            expect(subject['scores']['Ari']).to \
+              eq text[:scores][:ari]
+            expect(subject['scores']['ColemanLiau']).to \
+              eq text[:scores][:coleman_liau]
+            expect(subject['scores']['FleschKincaidGl']).to \
+              eq text[:scores][:flesch_kincaid_grade_level]
+            expect(subject['scores']['FleschKincaidRe']).to \
+              eq text[:scores][:flesch_kincaid_reading_ease]
+            expect(subject['scores']['GunningFog']).to \
+              eq text[:scores][:gunning_fog]
+            expect(subject['scores']['Smog']).to \
+              eq text[:scores][:smog]
+          end
+        end
+
+        describe "['string_length']" do
+          it 'returns the number of characters (including whitespace)' do
+            expect(subject['string_length']).to eq text[:data][:string_length]
+          end
+        end
+
+        describe "['letter_count']" do
+          it 'returns the number of letters' do
+            expect(subject['letter_count']).to eq text[:data][:letter_count]
+          end
+        end
+
+        describe "['syllable_count']" do
+          it 'returns the number of syllables' do
+            expect(subject['syllable_count']).to eq text[:data][:syllable_count]
+          end
+        end
+
+        describe "['word_count']" do
+          it 'returns the number of words' do
+            expect(subject['word_count']).to eq text[:data][:word_count]
+          end
+        end
+
+        describe "['sentence_count']" do
+          it 'returns the number of sentences' do
+            expect(subject['sentence_count']).to eq text[:data][:sentence_count]
+          end
+        end
+
+        describe "['average_words_per_sentence']" do
+          it 'returns the average words per sentences' do
+            expect(subject['average_words_per_sentence']).to \
+              eq text[:data][:average_words_per_sentence]
+          end
+        end
+
+        describe "['average_syllables_per_word']" do
+          it 'returns the average syllables per word' do
+            expect(subject['average_syllables_per_word']).to \
+              eq text[:data][:average_syllables_per_word]
+          end
+        end
+      end
+    end
+
+    describe '.analyze_all' do
       let :analyze_all do
         {
-         'string_length' => 13,
-         'letter_count' => 10,
-         'syllable_count' => 3,
-         'word_count' => 3,
-         'sentence_count' => 1,
-         'average_words_per_sentence' => 3.0,
-         'average_syllables_per_word' => 1.0,
+         'string_length' => text[:data][:string_length],
+         'letter_count' => text[:data][:letter_count],
+         'syllable_count' => text[:data][:syllable_count],
+         'word_count' => text[:data][:word_count],
+         'sentence_count' => text[:data][:sentence_count],
+         'average_words_per_sentence' => text[:data][:average_words_per_sentence],
+         'average_syllables_per_word' => text[:data][:average_syllables_per_word],
          'scores' => {
-           'Ari' => -4.2,
-           'ColemanLiau' => 3.7,
-           'FleschKincaidGl' => -2.6,
-           'FleschKincaidRe' => 119.2,
-           'GunningFog' => 1.2,
-           'Smog' => 3.1
+           'Ari' => text[:scores][:ari],
+           'ColemanLiau' => text[:scores][:coleman_liau],
+           'FleschKincaidGl' => text[:scores][:flesch_kincaid_grade_level],
+           'FleschKincaidRe' => text[:scores][:flesch_kincaid_reading_ease],
+           'GunningFog' => text[:scores][:gunning_fog],
+           'Smog' => text[:scores][:smog]
           }
         }
       end
 
       it 'should call analyze_multi' do
-        expect(Odyssey).to receive(:analyze_multi).with(one_simple_sentence, Array, true)
-        Odyssey.analyze_all one_simple_sentence
+        expect(Odyssey).to receive(:analyze_multi).with(text[:text], Array, true)
+        Odyssey.analyze_all text[:text]
       end
 
       it 'should return a Hash' do
-        expect(Odyssey.analyze_all one_simple_sentence).to be_a Hash
+        expect(Odyssey.analyze_all text[:text]).to be_a Hash
       end
 
       it 'returns all scores and info' do
-        expect(Odyssey.analyze_all one_simple_sentence).to eq analyze_all
+        expect(Odyssey.analyze_all text[:text]).to eq analyze_all
       end
     end
   end
+end
 
+describe Odyssey do
   describe 'plugin formulas' do
     it 'should run any formula using a shortcut method' do
-      result = Odyssey.fake_formula one_simple_sentence, true
-      result['name'].should == "It's fake"
+      result = Odyssey.fake_formula 'an example sentence', true
+      expect(result['name']).to eq "It's fake"
     end
 
     it 'should raise an error for a formula that does not exist' do
-      expect { Odyssey.no_existe one_simple_sentence, true }.to raise_error(NoMethodError)
+      expect { Odyssey.no_existe 'another example sentence', true }.to \
+        raise_error(NoMethodError)
+    end
+  end
+
+  describe '.analyze_multi' do
+    context 'with no formulas provided to multi' do
+      it 'should raise an error for empty formula list' do
+        expect { Odyssey.analyze_multi 'one more example sentence', [] }.to \
+          raise_error(ArgumentError)
+      end
+    end
+  end
+end
+
+describe Odyssey do
+  describe 'plugin formulas' do
+    it 'should run any formula using a shortcut method' do
+      result = Odyssey.fake_formula 'an example sentence', true
+      expect(result['name']).to eq "It's fake"
+    end
+
+    it 'should raise an error for a formula that does not exist' do
+      expect { Odyssey.no_existe 'another example sentence', true }.to \
+        raise_error(NoMethodError)
+    end
+  end
+
+  describe '.analyze_multi' do
+    context 'with no formulas provided to multi' do
+      it 'should raise an error for empty formula list' do
+        expect { Odyssey.analyze_multi 'one more example sentence', [] }.to \
+          raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,28 +1,31 @@
 require 'rspec'
 require 'odyssey'
 
-RSpec.configure do |config|
-  config.color = true
-  config.formatter     = 'documentation'
-  config.expect_with(:rspec) { |c| c.syntax = %i[should expect] }
+require 'pathname'
+require 'yaml'
+
+require 'active_support/core_ext/hash/keys'
+require 'active_support/core_ext/object/blank'
+
+PENDING_TEXTS = [
+]
+
+module Helpers
 end
 
-def one_simple_sentence
-  "See Spot run."
+def fixture_texts
+  Dir.glob("#{Pathname.new(__dir__).realpath + 'fixtures'}/*.yml").map do |f|
+   YAML.load_file(f).deep_symbolize_keys
+  end.reject do |text|
+    PENDING_TEXTS.include? text[:title]
+  end.each do |text|
+    text[:text] = text[:text].strip if text[:text].present?
+  end
 end
 
-def two_simple_sentences
-  "See Spot run. See Spot jump."
-end
-
-def one_complex_sentence
-  "The quick brown fox jumps over the lazy dog."
-end
-
-def two_complex_sentences
-  "The quick brown fox jumps over the lazy dog. Peter Piper picked a peck of pickled peppers."
-end
-
-def very_complex
-  "The best things in an artist's work are so much a matter of intuition, that there is much to be said for the point of view that would altogether discourage intellectual inquiry into artistic phenomena on the part of the artist. Intuitions are shy things and apt to disappear if looked into too closely. And there is undoubtedly a danger that too much knowledge and training may supplant the natural intuitive feeling of a student, leaving only a cold knowledge of the means of expression in its place. For the artist, if he has the right stuff in him"
+RSpec.configure do |c|
+  c.color = true
+  c.formatter = 'documentation'
+  c.expect_with(:rspec) { |c| c.syntax = :expect }
+  c.include Helpers
 end


### PR DESCRIPTION
Adds some spec data (copyright free), and updates the specs.

Removes all of the `should` syntax in our specs, and replaces them with the more common/modern/supported `expect` syntax.

Moves all the hardcoded values from the specs into the texts themselves, which are in yaml.

---

As referenced in https://github.com/cameronsutter/odyssey/pull/24#issuecomment-529025322

Resolves https://github.com/cameronsutter/odyssey/issues/23