### PR TITLE
Add Odyssey#analyze_all and String#readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ if all_stats is true, this returns a Hash, similar to the Hash above:
       'average_syllables_per_word' => Float
     }
 
+In order to get all stats and scores, you can use this shortcut:
+
+    Odyssey.analyze_all(text)
+
+or, using `Odyssey::Refinements`:
+
+    using Odyssey::Refinements
+    text.readability
+
 ## Extending Odyssey
 
 To extend Odyssey, you can create a class that inherits from `Odyssey::Formula`.

--- a/lib/odyssey.rb
+++ b/lib/odyssey.rb
@@ -44,6 +44,11 @@ module Odyssey
     output
   end
 
+  def self.analyze_all(text)
+    formulas = %w[Ari ColemanLiau FleschKincaidGl FleschKincaidRe GunningFog Smog]
+    analyze_multi text, formulas, true
+  end
+
   #run whatever method was given as if it were a shortcut to a formula
   def self.method_missing(method_name, *args, &block)
     #send to the main method
@@ -59,6 +64,7 @@ module Odyssey
 end
 
 require 'odyssey/engine'
+require 'odyssey/refinements'
 require 'odyssey/formulas/formula'
 
 require 'odyssey/formulas/ari'

--- a/lib/odyssey/refinements.rb
+++ b/lib/odyssey/refinements.rb
@@ -1,0 +1,9 @@
+module Odyssey
+  module Refinements
+    refine String do
+      def readability
+        Odyssey.analyze_all self
+      end
+    end
+  end
+end

--- a/spec/odyssey/refinements_spec.rb
+++ b/spec/odyssey/refinements_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+using Odyssey::Refinements
+
+describe Odyssey::Refinements do
+  describe String do
+    describe '#readability' do
+      it "calls Odyssey#analyze_all" do
+        expect(Odyssey).to receive(:analyze_all).with(one_simple_sentence)
+        one_simple_sentence.readability
+      end
+    end
+  end
+end

--- a/spec/odyssey_spec.rb
+++ b/spec/odyssey_spec.rb
@@ -114,17 +114,35 @@ describe Odyssey do
         @simple_stats['formula'].should be_nil
         @simple_stats['score'].should   be_nil
       end
-
     end
 
     it 'should raise an error for empty formula list' do
-      expect { Odyssey.analyze_multi one_simple_sentence, []}.to raise_error(ArgumentError)
+      expect { Odyssey.analyze_multi one_simple_sentence, [] }.to raise_error(ArgumentError)
     end
-
   end
 
   context 'Run all formulas' do
     describe 'get scores' do
+      let :analyze_all do
+        {
+         'string_length' => 13,
+         'letter_count' => 10,
+         'syllable_count' => 3,
+         'word_count' => 3,
+         'sentence_count' => 1,
+         'average_words_per_sentence' => 3.0,
+         'average_syllables_per_word' => 1.0,
+         'scores' => {
+           'Ari' => -4.2,
+           'ColemanLiau' => 3.7,
+           'FleschKincaidGl' => -2.6,
+           'FleschKincaidRe' => 119.2,
+           'GunningFog' => 1.2,
+           'Smog' => 3.1
+          }
+        }
+      end
+
       it 'should call analyze_multi' do
         expect(Odyssey).to receive(:analyze_multi).with(one_simple_sentence, Array, true)
         Odyssey.analyze_all one_simple_sentence
@@ -132,6 +150,10 @@ describe Odyssey do
 
       it 'should return a Hash' do
         expect(Odyssey.analyze_all one_simple_sentence).to be_a Hash
+      end
+
+      it 'returns all scores and info' do
+        expect(Odyssey.analyze_all one_simple_sentence).to eq analyze_all
       end
     end
   end

--- a/spec/odyssey_spec.rb
+++ b/spec/odyssey_spec.rb
@@ -123,6 +123,19 @@ describe Odyssey do
 
   end
 
+  context 'Run all formulas' do
+    describe 'get scores' do
+      it 'should call analyze_multi' do
+        expect(Odyssey).to receive(:analyze_multi).with(one_simple_sentence, Array, true)
+        Odyssey.analyze_all one_simple_sentence
+      end
+
+      it 'should return a Hash' do
+        expect(Odyssey.analyze_all one_simple_sentence).to be_a Hash
+      end
+    end
+  end
+
   describe 'plugin formulas' do
     it 'should run any formula using a shortcut method' do
       result = Odyssey.fake_formula one_simple_sentence, true


### PR DESCRIPTION
using Odyssey, I found myself constantly copy-pasting this function from project to project:

```ruby
all_stats = true
formulas = %w[
  Ari
  ColemanLiau
  FleschKincaidGl
  FleschKincaidRe
  GunningFog
  Smog
]

result = Odyssey.analyze_multi text, formulas, all_stats
```

So, I figured it could be nice if we don't have to.

This PR adds two convenience wrappers:

1. `Odyssey#analyze_all` which is a shortcut to `Odyssey#analyze_multi` with all formulas and `all_stats=true`
2. A String refinement, so everybody `using` it, can do `text.readability` and get the same `Odyssey#analyze_all`

I updated the tests and README to the best of my ability, trying to maintain the same original style.

Will you consider merging?


